### PR TITLE
Fix RawParams merge position

### DIFF
--- a/powershai/providers/openai.ps1
+++ b/powershai/providers/openai.ps1
@@ -483,9 +483,6 @@ function Get-OpenaiChat {
 			
 			
 			
-			if($RawParams){
-				$RawParams.keys | %{ $Body[$_] = $RawParams[$_] }
-			}
 			
 			if($ResponseFormat){
 				$Body.response_format = $ResponseFormat
@@ -496,13 +493,16 @@ function Get-OpenaiChat {
 				$Body.tool_choice = "auto";
 			}
 			
-			if($StreamCallback){
-				$body.stream = $true;
-				$body.stream_options = @{include_usage = $true};
-			}
+                        if($StreamCallback){
+                                $body.stream = $true;
+                                $body.stream_options = @{include_usage = $true};
+                        }
 
-			
-			$StreamData = @{
+                        if($RawParams){
+                                $Body = HashTableMerge $Body $RawParams
+                        }
+
+                        $StreamData = @{
 				#Todas as respostas enviadas!
 				answers = @()
 				


### PR DESCRIPTION
## Summary
- call `HashTableMerge` for raw OpenAI params
- move RawParams merge after the stream callback setup so overrides work

## Testing
- `pwsh -NoLogo -NoProfile -c "echo test"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b5b6b9888321814675930f57541b